### PR TITLE
Refactor ci build

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -26,11 +26,12 @@ rollup.*.js
 tsconfig.json
 !dist
 
-# TODO: check for any performance gain on Cloud Build when uploading node_modules
+# Debug: check for performance gain on Cloud Build when uploading node_modules...
 #   GAE will install node_modules no matter what with it's Cloud Build step.
 #   GAE requires yarn.lock to install them.
-#   Currently node_modules upload skipped with #!include:.gitignore
+#   node_modules upload skipped with #!include:.gitignore, reverting that here
 #   Could uploading node_modules reduce Cloud Build time?
+!node_modules
 
 # Generated static files
 !public/dist/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -17,5 +17,9 @@ sonar-project.properties
 .gitignore
 #!include:.gitignore
 
+/src/
+!node_modules
+!dist
+
 # Generated static files
 !public/dist/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -26,12 +26,14 @@ rollup.*.js
 tsconfig.json
 !dist
 
-# Debug: check for performance gain on Cloud Build when uploading node_modules...
-#   GAE will install node_modules no matter what with it's Cloud Build step.
-#   GAE requires yarn.lock to install them.
-#   node_modules upload skipped with #!include:.gitignore, reverting that here
-#   Could uploading node_modules reduce Cloud Build time?
-!node_modules
+# Note preinstall script in the package.json!
+# It will unpack uploaded node_modules.tar.gz before installing dependencies.
+# node_modules dir upload is skipped deliberately (with #!include:.gitignore).
+# Cloud Build step for GAE standard environment removes node_modules dir before running yarn install step.
+# Here is an explanation for this hack: https://stackoverflow.com/a/39028187/1412330
+# Also note:
+# Not uploading package.json and yarn.lock while uploading node_modules will not work,
+# GAE requires either one of those and always runs npm/yarn install step.
 
 # Generated static files
 !public/dist/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -18,6 +18,7 @@ sonar-project.properties
 #!include:.gitignore
 
 /src/
+/templates/style/
 rollup.*.js
 tsconfig.json
 !node_modules

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -18,6 +18,8 @@ sonar-project.properties
 #!include:.gitignore
 
 /src/
+rollup.*.js
+tsconfig.json
 !node_modules
 !dist
 

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -17,12 +17,20 @@ sonar-project.properties
 .gitignore
 #!include:.gitignore
 
+# Explainer:
+# App is built with Github Actions workflow, check out .github/workflows/main.yml
+# So, GAE upload will skip sources and build configs, and upload dist files instead.
 /src/
 /templates/style/
 rollup.*.js
 tsconfig.json
-!node_modules
 !dist
+
+# TODO: check for any performance gain on Cloud Build when uploading node_modules
+#   GAE will install node_modules no matter what with it's Cloud Build step.
+#   GAE requires yarn.lock to install them.
+#   Currently node_modules upload skipped with #!include:.gitignore
+#   Could uploading node_modules reduce Cloud Build time?
 
 # Generated static files
 !public/dist/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+            yarn-
+
       - name: Run linters
         run: |
-          yarn install --frozen-lockfile
+          yarn install --production=false --frozen-lockfile --non-interactive
           yarn lint
           yarn slint
 
@@ -62,11 +71,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+            yarn-
+
       - name: Generate static route handlers
         run: |
-          yarn install --frozen-lockfile
+          yarn install --production=false --frozen-lockfile --non-interactive
           yarn build-frontend
           yarn static
+
+      - name: Build backend and cleanup for deploy
+        run: |
+          yarn build
+          rm -rf node_modules
+          yarn install --production --frozen-lockfile --non-interactive
 
       - name: Import Service Account key
         run: echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > /tmp/auth.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: app-engine
 env:
   GCLOUD_PROJECT_ID: kvaapagarrot
   NODE_ENV: production
-  APP_VERSION: ${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}
+  APP_VERSION: "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}"
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: app-engine
 
 env:
   GCLOUD_PROJECT_ID: kvaapagarrot
+  NODE_ENV: production
 
 on:
   push:
@@ -17,7 +18,9 @@ jobs:
   cancel-previous:
     name: Cancel Previous Jobs
     # Skip workflow entirely for [skip ci] commits
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[no ci]') }}
+    if: |
+      false == contains(github.event.commits[0].message, '[skip ci]') &&
+      false == contains(github.event.commits[0].message, '[no ci]')
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
@@ -28,7 +31,9 @@ jobs:
   lint:
     name: Lint Code
     # Skip workflow entirely for [skip ci] commits
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[no ci]') }}
+    if: |
+      false == contains(github.event.commits[0].message, '[skip ci]') &&
+      false == contains(github.event.commits[0].message, '[no ci]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,14 +41,16 @@ jobs:
 
       - name: Run linters
         run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn lint
           yarn slint
 
   deploy-gae:
     name: App Engine Deployment
     # Skip workflow entirely for [skip ci] commits
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') && !contains(github.event.commits[0].message, '[no ci]') }}
+    if: |
+      false == contains(github.event.commits[0].message, '[skip ci]') &&
+      false == contains(github.event.commits[0].message, '[no ci]')
     runs-on: ubuntu-latest
     needs: [lint]
     # Map a step output to a job output
@@ -56,7 +63,7 @@ jobs:
 
       - name: Generate static route handlers
         run: |
-          yarn install
+          yarn install --frozen-lockfile
           yarn build-frontend
           yarn static
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,10 @@ jobs:
       false == contains(github.event.commits[0].message, '[skip ci]') &&
       false == contains(github.event.commits[0].message, '[no ci]')
     runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      yarn-cache-dir: ${{ steps.yarn-cache-dir.outputs.dir }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -89,7 +93,7 @@ jobs:
       - name: Cache node modules
         uses: actions/cache@v2
         with:
-          path: ${{ needs.lint.steps.yarn-cache-dir.outputs.dir }}
+          path: ${{needs.lint.outputs.yarn-cache-dir}}
           key: yarn-cache-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn-cache-${{ runner.os }}-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,9 +108,11 @@ jobs:
       - name: Generate static route handlers
         run: yarn static
 
-      - name: Keep only prod dependencies for GAE upload
+      - name: Save prod dependencies for GAE upload
         run: |
           yarn install --production=true --frozen-lockfile --non-interactive
+          tar -czf node_modules.tar.gz node_modules
+          ls -lah node_modules.tar.gz | awk '{print $5,$9}'
 
       - name: Import Service Account key
         run: echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > /tmp/auth.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,9 +100,9 @@ jobs:
       - name: Generate static route handlers
         run: yarn static
 
-#      - name: Keep prod node_modules for GAE upload
-#        run: |
-#          yarn install --production=true --frozen-lockfile --non-interactive --force
+      - name: Keep prod node_modules for GAE upload
+        run: |
+          yarn install --production=true --frozen-lockfile --non-interactive --force
 
       - name: Import Service Account key
         run: echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > /tmp/auth.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: app-engine
 env:
   GCLOUD_PROJECT_ID: kvaapagarrot
   NODE_ENV: production
+  APP_VERSION: ${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}
 
 on:
   push:
@@ -79,12 +80,12 @@ jobs:
 
       - name: Deploy
         run: |
-          gcloud --quiet app deploy app.yaml --no-promote --version "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}"
+          gcloud --quiet app deploy app.yaml --no-promote --version "${APP_VERSION}"
 
       - id: version-url
         name: Get deployed app version URL
         run: |
-          VERSION_URL=$(gcloud app versions describe "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}" --service=default --format "value(versionUrl)")
+          VERSION_URL=$(gcloud app versions describe "${APP_VERSION}" --service=default --format "value(versionUrl)")
           echo $VERSION_URL
           echo "::set-output name=url::$(echo $VERSION_URL)"
 
@@ -133,4 +134,4 @@ jobs:
 
       - name: Promote deployed version to production
         run: |
-          gcloud --quiet app versions migrate "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}" --service=default
+          gcloud --quiet app versions migrate "${APP_VERSION}" --service=default

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,14 +45,18 @@ jobs:
         with:
           node-version: '14.15.4'
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache node modules
         uses: actions/cache@v2
         with:
-          path: node_modules
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: yarn-cache-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            yarn-${{ runner.os }}-
-            yarn-
+            yarn-cache-${{ runner.os }}-
+            yarn-cache-
 
       - name: Run linters
         run: |
@@ -85,11 +89,11 @@ jobs:
       - name: Cache node modules
         uses: actions/cache@v2
         with:
-          path: node_modules
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          path: ${{needs.lint.outputs.yarn-cache-dir}}
+          key: yarn-cache-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            yarn-${{ runner.os }}-
-            yarn-
+            yarn-cache-${{ runner.os }}-
+            yarn-cache-
 
       - name: Build all
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - name: Cache node modules
         uses: actions/cache@v2
         with:
@@ -70,6 +74,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         id: yarn-cache-dir
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Cache node modules
+      - name: Cache yarn cache dir
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
@@ -61,6 +61,15 @@ jobs:
           restore-keys: |
             yarn-cache-${{ runner.os }}-
             yarn-cache-
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            node_modules-${{ runner.os }}-
+            node_modules-
 
       - name: Run linters
         run: |
@@ -90,7 +99,7 @@ jobs:
         with:
           node-version: '14.15.4'
 
-      - name: Cache node modules
+      - name: Cache yarn cache dir
         uses: actions/cache@v2
         with:
           path: ${{needs.lint.outputs.yarn-cache-dir}}
@@ -98,6 +107,15 @@ jobs:
           restore-keys: |
             yarn-cache-${{ runner.os }}-
             yarn-cache-
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            node_modules-${{ runner.os }}-
+            node_modules-
 
       - name: Build all
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,9 +100,9 @@ jobs:
       - name: Generate static route handlers
         run: yarn static
 
-      - name: Keep prod node_modules for GAE upload
+      - name: Keep only prod dependencies for GAE upload
         run: |
-          yarn install --production=true --frozen-lockfile --non-interactive --force
+          yarn install --production=true --frozen-lockfile --non-interactive
 
       - name: Import Service Account key
         run: echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > /tmp/auth.json
@@ -116,7 +116,7 @@ jobs:
 
       - name: Deploy
         run: |
-          gcloud --quiet app deploy app.yaml --no-promote --version "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}"
+          gcloud --quiet app deploy app.yaml --no-cache --no-promote --version "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}"
 
       - id: version-url
         name: Get deployed app version URL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      # Preferable to use the same version as in GAE environment
+      - name: Set Node.js version
+        uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '14.15.4'
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -74,9 +76,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      # Preferable to use the same version as in GAE environment
+      - name: Set Node.js version
+        uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '14.15.4'
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -87,17 +91,18 @@ jobs:
             yarn-${{ runner.os }}-
             yarn-
 
-      - name: Generate static route handlers
+      - name: Build all
         run: |
           yarn install --production=false --frozen-lockfile --non-interactive
-          yarn build-frontend
-          yarn static
-
-      - name: Build backend and cleanup for deploy
-        run: |
           yarn build
-          rm -rf node_modules
-          yarn install --production --frozen-lockfile --non-interactive
+          rm public/dist/main.js
+
+      - name: Generate static route handlers
+        run: yarn static
+
+#      - name: Keep prod node_modules for GAE upload
+#        run: |
+#          yarn install --production=true --frozen-lockfile --non-interactive --force
 
       - name: Import Service Account key
         run: echo "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}" | base64 -d > /tmp/auth.json
@@ -134,6 +139,9 @@ jobs:
         run: |
           curl "https://raw.githubusercontent.com/irkfap/kvaapagarrot.com/${GITHUB_SHA}/lighthouserc.json" \
           --silent --location --output "$GITHUB_WORKSPACE/lighthouserc.json"
+
+      - name: Warmup deployed instance
+        run: curl -sIX GET "${{needs.deploy-gae.outputs.version-url}}"
 
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Cache node modules
         uses: actions/cache@v2
         with:
-          path: ${{needs.lint.outputs.yarn-cache-dir}}
+          path: ${{ needs.lint.steps.yarn-cache-dir.outputs.dir }}
           key: yarn-cache-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn-cache-${{ runner.os }}-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ name: app-engine
 env:
   GCLOUD_PROJECT_ID: kvaapagarrot
   NODE_ENV: production
-  APP_VERSION: "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}"
 
 on:
   push:
@@ -112,12 +111,12 @@ jobs:
 
       - name: Deploy
         run: |
-          gcloud --quiet app deploy app.yaml --no-promote --version "${APP_VERSION}"
+          gcloud --quiet app deploy app.yaml --no-promote --version "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}"
 
       - id: version-url
         name: Get deployed app version URL
         run: |
-          VERSION_URL=$(gcloud app versions describe "${APP_VERSION}" --service=default --format "value(versionUrl)")
+          VERSION_URL=$(gcloud app versions describe "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}" --service=default --format "value(versionUrl)")
           echo $VERSION_URL
           echo "::set-output name=url::$(echo $VERSION_URL)"
 
@@ -166,4 +165,4 @@ jobs:
 
       - name: Promote deployed version to production
         run: |
-          gcloud --quiet app versions migrate "${APP_VERSION}" --service=default
+          gcloud --quiet app versions migrate "${GITHUB_ACTOR//[\[\]]/}-${GITHUB_SHA:0:7}" --service=default

--- a/app.yaml
+++ b/app.yaml
@@ -23,7 +23,9 @@ inbound_services:
 
 default_expiration: "7d"
 
-# @see scripts/make-static-handlers.ts
-# run with: yarn static
+# Static routes are generated before gcloud app deploy
+# Check out scripts/make-static-handlers.ts
+# Run manually with: yarn static
+# Not required for dev server (static files are served by Fastify)
 includes:
   - routes.yaml

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 # https://cloud.google.com/appengine/docs/standard/nodejs/config/appref
 
-runtime: nodejs12
+runtime: nodejs14
 instance_class: F1
 
 automatic_scaling:
@@ -17,8 +17,6 @@ entrypoint: node -r source-map-support/register dist/main
 
 env_variables:
   NODE_ENV: production
-  # Discard Nodejs 12 stderr pollution: "ExperimentalWarning: The ESM module loader is experimental."
-  NODE_NO_WARNINGS: 1
 
 inbound_services:
   - warmup

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-frontend": "rollup -c rollup.frontend.config.js && rm public/dist/main.js",
     "deploy": "gcloud app deploy app.yaml --project kvaapagarrot --quiet",
     "lint": "eslint '**/*.ts'",
+    "preinstall": "test -f node_modules.tar.gz && tar -xzf node_modules.tar.gz && rm -f node_modules.tar.gz || true",
     "slint": "stylelint '**/*.pcss'",
     "start": "node -r source-map-support/register dist/main",
     "static": "tsc -p scripts && node -r source-map-support/register scripts/dist/make-static-handlers",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,9 @@
   },
   "type": "module",
   "scripts": {
-    "build": "NODE_ENV=development rollup -c",
+    "build": "rollup -c",
     "build-frontend": "rollup -c rollup.frontend.config.js && rm public/dist/main.js",
     "deploy": "gcloud app deploy app.yaml --project kvaapagarrot --quiet",
-    "gcp-build": "NODE_ENV=production rollup -c",
     "lint": "eslint '**/*.ts'",
     "slint": "stylelint '**/*.pcss'",
     "start": "node -r source-map-support/register dist/main",


### PR DESCRIPTION
- [x] Move build stage from Google Platform to Github Actions (eliminate gcp-build)
- [x] Upload node_modules instead of installing them with Google Platform Build
  Note buildpack [will always remove node_modules](https://github.com/GoogleCloudPlatform/buildpacks/blob/89f4a6ba669437a47b482f4928f974d8b3ee666d/cmd/nodejs/yarn/main.go#L60), so [preinstall hack](https://stackoverflow.com/questions/37310253/how-to-force-app-engine-upload-node-modules/) is needed.
- [x] Move to Node.js 14 runtime
- [x] Remove `yarn build-frontend` redundant build step (`yarn build` builds both back and front)

Goal is to reduce Cloud Build time.
Achieved: from 1m40s (builder step 0:42, exporter step 0:28) to 0m41s (builder step 0:02, exporter step 0:11).

Additional:
- [x] GH Actions: cache yarn cache dir 
- [x] GH Actions: cache node_modules dir (in addition to yarn cache) to reduce `yarn install` time even more.